### PR TITLE
New Name Scheme of ExportFile but preserve App's original File Name scheme

### DIFF
--- a/app/src/main/java/com/tomclaw/appsend_rb/util/Files.kt
+++ b/app/src/main/java/com/tomclaw/appsend_rb/util/Files.kt
@@ -8,7 +8,7 @@ import com.tomclaw.appsend_rb.dto.AppEntity
 import java.io.File
 
 fun getApkPrefix(item: AppEntity): String {
-    return escapeFileSymbols(item.packageName + "_" + item.versionName)
+    return escapeFileSymbols(item.label + "-" + item.versionCode + "_" + item.versionName)
 }
 
 fun getApkSuffix(): String {


### PR DESCRIPTION
This PR changes the exported file name to the app name followed by internal version code and then follwed by proper version number

Internal code significantly matters in installing previous versions of the apps through Aurora Store (A Foss Play Store Alternative) for downgrade purposes that's what makes this app different from most of other apk exporting apps.